### PR TITLE
Default disable FOC_CC_DECOUPLING

### DIFF
--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -351,7 +351,7 @@
 #define MCCONF_FOC_CURRENT_FILTER_CONST	0.1		// Filter constant for the filtered currents
 #endif
 #ifndef MCCONF_FOC_CC_DECOUPLING
-#define MCCONF_FOC_CC_DECOUPLING		FOC_CC_DECOUPLING_BEMF // Current controller decoupling
+#define MCCONF_FOC_CC_DECOUPLING		FOC_CC_DECOUPLING_DISABLED // Current controller decoupling
 #endif
 #ifndef MCCONF_FOC_OBSERVER_TYPE
 #define MCCONF_FOC_OBSERVER_TYPE		FOC_OBSERVER_ORTEGA_ORIGINAL // Position observer type for FOC


### PR DESCRIPTION
The “decoupling” parameter relies on the speed estimate, which is notorious for lagging behind actual speed.

The end result is that the PI current controller and “decoupling” start fighting each other.